### PR TITLE
Add support for alternate services with 'Endpoint'

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ can provide credentials required for using private apt repositories.
 
 NOTE: Region MUST match the region the buckets are stored in and if not defined defaults to us-east-1.
 
+Setting Endpoint allows for using providers other than Amazon AWS. If set, Endpoint disregards Region.
+
 Example of s3auth.conf file:
 ```
 AccessKeyId = myaccesskey
 SecretAccessKey = mysecretaccesskey
 Region = 'us-east-1'
+Endpoint = 'nyc3.digitaloceanspaces.com'
 ```
 
 ## Usage

--- a/s3
+++ b/s3
@@ -160,6 +160,10 @@ class AWSCredentials(object):
             else:
                 raise Exception("GetCredentials request timed out")
 
+        if data.get('Endpoint') is None:
+            self.host = 's3.{}.amazonaws.com'.format(self.region)
+        self.host = data['Endpoint']
+
         self.access_key = data['AccessKeyId']
         if self.access_key is None or self.access_key == '':
             raise Exception("AccessKeyId required")
@@ -214,7 +218,7 @@ class AWSCredentials(object):
         # quote path for +, ~, and spaces
         # see bugs.launchpad.net #1003633 and #1086997
         scheme = 'https'
-        host = 's3.{}.amazonaws.com'.format(self.region)
+        host = self.host
         bucket = uri_parsed.netloc
         path = '/{}{}'.format(bucket, self._quote(uri_parsed.path, '+~ '))
 


### PR DESCRIPTION
This adds a new option, Endpoint, that controls which host is contacted so that apt-transport-s3 can be used with alternate S3-compatible service providers. The default remains AWS.