### PR TITLE
Add support for special AWS regions (cn-north-1 and cn-northwest-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ can provide credentials required for using private apt repositories.
 
 NOTE: Region MUST match the region the buckets are stored in and if not defined defaults to us-east-1.
 
+Setting Endpoint allows for using providers other than Amazon AWS. If set, Endpoint disregards Region.
+
 Example of s3auth.conf file:
 ```
 AccessKeyId = myaccesskey
 SecretAccessKey = mysecretaccesskey
 Region = 'us-east-1'
+Endpoint = 'nyc3.digitaloceanspaces.com'
 ```
 
 ## Usage

--- a/s3
+++ b/s3
@@ -32,15 +32,15 @@ from configobj import ConfigObj
 
 RETRIES = 5
 
+SPECIAL_REGION_ENDPOINTS = {
+    'cn-north-1': 's3.cn-north-1.amazonaws.com.cn',
+    'cn-northwest-1': 's3.cn-northwest-1.amazonaws.com.cn'
+}
+
 
 def wait_time(c):
     return pow(2, c) - 1
 
-RETRIES = 5
-
-
-def wait_time(c):
-    return pow(2, c) - 1
 
 
 class AWSCredentials(object):
@@ -160,9 +160,12 @@ class AWSCredentials(object):
             else:
                 raise Exception("GetCredentials request timed out")
 
-        if data.get('Endpoint') is None:
-            self.host = 's3.{}.amazonaws.com'.format(self.region)
         self.host = data['Endpoint']
+        if data.get('Endpoint') is None:
+            if self.region not in SPECIAL_REGION_ENDPOINTS.keys():
+                self.host = 's3.{}.amazonaws.com'.format(self.region)
+            else:
+                self.host = SPECIAL_REGION_ENDPOINTS[self.region]
 
         self.access_key = data['AccessKeyId']
         if self.access_key is None or self.access_key == '':

--- a/s3
+++ b/s3
@@ -160,6 +160,10 @@ class AWSCredentials(object):
             else:
                 raise Exception("GetCredentials request timed out")
 
+        if data.get('Endpoint') is None:
+            self.host = 's3.{}.amazonaws.com'.format(self.region)
+        self.host = data['Endpoint']
+
         self.access_key = data['AccessKeyId']
         if self.access_key is None or self.access_key == '':
             raise Exception("AccessKeyId required")
@@ -214,7 +218,7 @@ class AWSCredentials(object):
         # quote path for +, ~, and spaces
         # see bugs.launchpad.net #1003633 and #1086997
         scheme = 'https'
-        host = 's3.{}.amazonaws.com'.format(self.region)
+        host = self.host
         bucket = uri_parsed.netloc
         path = '/{}{}'.format(bucket, self._quote(uri_parsed.path, '+~ '))
 

--- a/s3
+++ b/s3
@@ -160,12 +160,13 @@ class AWSCredentials(object):
             else:
                 raise Exception("GetCredentials request timed out")
 
-        self.host = data['Endpoint']
         if data.get('Endpoint') is None:
             if self.region not in SPECIAL_REGION_ENDPOINTS.keys():
                 self.host = 's3.{}.amazonaws.com'.format(self.region)
             else:
                 self.host = SPECIAL_REGION_ENDPOINTS[self.region]
+        else:
+            self.host = data['Endpoint']
 
         self.access_key = data['AccessKeyId']
         if self.access_key is None or self.access_key == '':


### PR DESCRIPTION
AWS China is isolated from the rest of the world, thus having different domain names. This CL adds support for it.