### PR TITLE
decode urllib response with utf

### DIFF
--- a/s3
+++ b/s3
@@ -69,7 +69,7 @@ class AWSCredentials(object):
         for i in range(0, RETRIES):
             try:
                 response = urllib.request.urlopen(request, None, 10)
-                self.iamrole = response.read()
+                self.iamrole = response.read().decode('utf-8')
                 break
             except ssl.SSLError as e:
                 if 'timed out' in e.message:
@@ -114,7 +114,7 @@ class AWSCredentials(object):
         for i in range(0, RETRIES):
             try:
                 response = urllib.request.urlopen(request, None, 30)
-                return json.loads(response.read())
+                return json.loads(response.read().decode('utf-8'))
             except ssl.SSLError as e:
                 if 'timed out' in e.message:
                     time.sleep(wait_time(i + 1))


### PR DESCRIPTION
Fix the 2 following issues which have the same root cause, which is a bad encoding on the response.

```
Traceback (most recent call last):
  File "/usr/lib/apt/methods/s3", line 606, in <module>
    method = S3_method(config)
  File "/usr/lib/apt/methods/s3", line 393, in __init__
    self.iam.get_credentials()
  File "/usr/lib/apt/methods/s3", line 201, in get_credentials
    self.iamrole.decode('utf-8')))
  File "/usr/lib/apt/methods/s3", line 123, in __request_json
    return json.loads(encode)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'dict'
```



Response is in `byte` but expected in `str`.

```
Traceback (most recent call last):
  File "/usr/lib/apt/methods/s3", line 597, in <module>
    method = S3_method(config)
  File "/usr/lib/apt/methods/s3", line 384, in __init__
    self.iam.get_credentials()
  File "/usr/lib/apt/methods/s3", line 192, in get_credentials
    self.iamrole))
  File "/usr/lib/python3.5/urllib/parse.py", line 435, in urljoin
    base, url, _coerce_result = _coerce_args(base, url)
  File "/usr/lib/python3.5/urllib/parse.py", line 111, in _coerce_args
    raise TypeError("Cannot mix str and non-str arguments")
TypeError: Cannot mix str and non-str arguments
```