### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ apt-transport-s3 (2.0.0-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Remove obsolete field Name from debian/upstream/metadata (already
+    present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 21:52:43 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+apt-transport-s3 (2.0.0-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 21:52:43 +0000
+
 apt-transport-s3 (2.0.0-1) unstable; urgency=medium
 
   [ Hayden Myers ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ apt-transport-s3 (2.0.0-2) UNRELEASED; urgency=medium
     Repository-Browse.
   * Remove obsolete field Name from debian/upstream/metadata (already
     present in machine-readable debian/copyright).
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 21:52:43 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Uploaders: Marcin Kulisz <debian@kulisz.net>,
 Build-Depends: python3,
                debhelper-compat (= 12),
                dh-python
-Standards-Version: 4.4.0
+Standards-Version: 4.5.0
 Homepage: https://github.com/MayaraCloud/apt-transport-s3
 Vcs-Git: https://salsa.debian.org/cloud-team/apt-transport-s3.git
 Vcs-Browser: https://salsa.debian.org/cloud-team/apt-transport-s3/tree/debian/sid

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,2 +1,5 @@
 Name: apt-transport-s3
-Repository: https://github.com/MayaraCloud/apt-transport-s3
+Bug-Database: https://github.com/MayaraCloud/apt-transport-s3/issues
+Bug-Submit: https://github.com/MayaraCloud/apt-transport-s3/issues/new
+Repository: https://github.com/MayaraCloud/apt-transport-s3.git
+Repository-Browse: https://github.com/MayaraCloud/apt-transport-s3

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,3 @@
-Name: apt-transport-s3
 Bug-Database: https://github.com/MayaraCloud/apt-transport-s3/issues
 Bug-Submit: https://github.com/MayaraCloud/apt-transport-s3/issues/new
 Repository: https://github.com/MayaraCloud/apt-transport-s3.git


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Remove obsolete field Name from debian/upstream/metadata (already present in machine-readable debian/copyright).
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/apt-transport-s3/a1733d88-73ca-4302-8e1f-f6648814b632.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a1733d88-73ca-4302-8e1f-f6648814b632/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a1733d88-73ca-4302-8e1f-f6648814b632/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a1733d88-73ca-4302-8e1f-f6648814b632/diffoscope)).
