### PR TITLE
fix ParseError

### DIFF
--- a/s3
+++ b/s3
@@ -521,7 +521,7 @@ class S3_method(object):
         """
         try:
             error = ET.fromstring(response.read())
-        except xml.etree.ElementTree.ParseError:
+        except ET.ParseError:
             return ''
 
         code = error.find('Code')


### PR DESCRIPTION
When there is a parsing error, instead of returning an empty string, it will throw an uncaught `NameError` exception

```
ip-10-1-10-127:apt-transport-s3 dustin$ python3
Python 3.8.4 (default, Jul 14 2020, 02:58:48)
[Clang 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import xml.etree.ElementTree as ET
>>> ET.ParseError
<class 'xml.etree.ElementTree.ParseError'>
>>> xml.etree.ElementTree.ParseError
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'xml' is not defined
```

It might be better to return a generic error message, but I didn't want to suggest that.  In it's current state, when there is an xml parsing error, the output from `apt-get` looks something like this:

```
E: Failed to fetch s3://xxx-apt-repo/xxx/xxx/xxx/xxx-xxx-xxx-xxx/xxx-xxx-xxx-xxx_1.x.xxx_amd64.deb  NameError: name 'xml' is not defined
```
