### PR TITLE
fix overeager replace in 02c2c6c

### DIFF
--- a/s3
+++ b/s3
@@ -314,7 +314,7 @@ class AWSCredentials(object):
         request.add_header('x-amz-content-sha256', self._payload_hash(request))
 
         # Create a date for headers and the credential string
-        amzdate = datetime.datetime.utcnow().strftime('%Y%m%dT%H%MgcZ')
+        amzdate = datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
 
         request.add_header('x-amz-date', amzdate)
 


### PR DESCRIPTION
02c2c6c replaced all %s by gc, including the %S of a datetime.
 => date format is incorrect
   ==> 403  Forbidden  [AccessDenied] AWS authentication requires a valid Date or x-amz-date header

This patch fixes that.
