### PR TITLE
Fix IAM error "decoding str is not supported"

### DIFF
--- a/s3
+++ b/s3
@@ -230,8 +230,7 @@ class AWSCredentials(object):
 
         if data.get("AccessKeyId") is None:
             self.__get_role()
-            data = self.__request_json(urllib.parse.urljoin(self.credentials_metadata,
-                                                            str(self.iamrole, 'utf-8')))
+            data = self.__request_json(urllib.parse.urljoin(self.credentials_metadata, self.iamrole))
 
         self.access_key = data['AccessKeyId']
         if self.access_key is None or self.access_key == '':


### PR DESCRIPTION
ce0064be41e1 established `self.iamrole` as a string. This caused an issue when credentials were not explicitly configured.

```
Traceback (most recent call last):
File \"/usr/lib/apt/methods/s3\", line 639, in <module>
method = S3_method(config)
File \"/usr/lib/apt/methods/s3\", line 426, in __init__
self.iam.get_credentials()
File \"/usr/lib/apt/methods/s3\", line 234, in get_credentials
str(self.iamrole, \'utf-8\')))
TypeError: decoding str is not supported
```

This commit removes a duplicate cast and allows IAM credentials to function properly.