### PR TITLE
Improve non-IMDS support

### DIFF
--- a/s3
+++ b/s3
@@ -221,16 +221,16 @@ class AWSCredentials(object):
         except:
             pass
 
-        self.region = self.__get_region(data)
-        self.host = self.__get_endpoint(data)
-
         # Setting up AWS creds based on environment variables if env vars
         # doesn't exist setting var value to None
         if data.get("AccessKeyId") is None:
-            data['AccessKeyId'] = os.environ.get("AWS_ACCESS_KEY_ID", None)
-            data['SecretAccessKey'] = os.environ.get(
-                "AWS_SECRET_ACCESS_KEY", None)
-            data['Token'] = os.environ.get("AWS_SESSION_TOKEN", None)
+            data['AccessKeyId'] = os.environ.get("AWS_ACCESS_KEY_ID")
+            data['SecretAccessKey'] = os.environ.get("AWS_SECRET_ACCESS_KEY")
+            data['Token'] = os.environ.get("AWS_SESSION_TOKEN")
+            data['Region'] = os.environ.get("AWS_REGION")
+
+        self.region = self.__get_region(data)
+        self.host = self.__get_endpoint(data)
 
         if data.get("AccessKeyId") is None:
             self.__get_role()


### PR DESCRIPTION
Currently, when not running in an EC2 instance, S3 transport fails
with "network unreachable" trying to connect to IMDSv2 even if all
the required environment variables are properly configured, because
region/endpoint lookup happens *before* environment variables are
ever processed.

This PR moves the block handling environment variables *before*
the region/endpoint lookup to _partially_ address that issue.

The missing piece for a _complete_ solution is to also check for and use
 `AWS_REGION` from the environment (as that will short-circuit the region
lookup, thus avoiding the failure to connect to IMDS).

With the proposed changes, the following steps work as expected,
with a properly configured/activated AWS profile *outside* EC2:
```sh
eval "$(aws configure export --format env)"
export AWS_REGION=$(aws configure get region)
apt update
```

As a cosmetic detail, the PR also removes the default `None` values
for the 2nd optional parameter to  `os.environ.get`.
