### PR TITLE
Fix path style support

### DIFF
--- a/s3
+++ b/s3
@@ -224,7 +224,7 @@ cause is that you don't have IAM role on this machine")
         If in the config is not a boolean but some rubish throw a type error.
         """
         # getting path style from config file
-        path_style = config.get('PathStyle')
+        path_style = config.as_bool('PathStyle')
 
         if not isinstance(path_style, bool):
             raise TypeError("PathStyle must be a boolean value")
@@ -256,6 +256,7 @@ cause is that you don't have IAM role on this machine")
 
         self.region = self.__get_region(data)
         self.host = self.__get_endpoint(data)
+        self.path_style = self.__get_path_style(data)
 
         if data.get("AccessKeyId") is None:
             self.__get_role()


### PR DESCRIPTION
In PR #65, @eduards-lasmanis suggested changes to support S3-compatible endpoints that use path style bucket URLs rather than DNS style bucket URLs, like `https://s3.example.com/my_bucket`. In commit 7130874ef561b5f0ed44fb9d2b6c16c1077c8813, those changes were adapted, but that adaptation lost two crucial elements:

- parsing the new `PathStyle` config option as a `bool`
- calling the new `__get_path_style` method to read the value and save it in the `AWSCredentials` object

As a result, trying to use `PathStyle = True` does not work, and the program tries to use subdomain style URLs - and of course fails if the service does not have subdomains configured.

Use `ConfigObj.as_bool`[1] instead of `dict.get` to correctly parse the new option, and call the new method in `AWSCredentials.get_credentials`.

[1] https://configobj.readthedocs.io/en/latest/configobj.html#section-methods