### PR TITLE
Fix the missing call for PathStyle parsing

### DIFF
--- a/s3
+++ b/s3
@@ -256,6 +256,7 @@ cause is that you don't have IAM role on this machine")
 
         self.region = self.__get_region(data)
         self.host = self.__get_endpoint(data)
+        self.path_style = self.__get_path_style(data)
 
         if data.get("AccessKeyId") is None:
             self.__get_role()


### PR DESCRIPTION
Functionality was implemented, but the value was not loaded to the object.
It drove me crazy :D could not figure out while the hostname does not exists.

This should fix the issue.