### PR TITLE
Feat: Allow bucket region to be specified in s3auth.conf or $AWS_REGION

### DIFF
--- a/s3
+++ b/s3
@@ -255,6 +255,8 @@ cause is that you don't have IAM role on this machine")
             data['AccessKeyId'] = os.environ.get("AWS_ACCESS_KEY_ID")
             data['SecretAccessKey'] = os.environ.get("AWS_SECRET_ACCESS_KEY")
             data['Token'] = os.environ.get("AWS_SESSION_TOKEN")
+
+        if data.get("Region") is None:
             data['Region'] = os.environ.get("AWS_REGION")
 
         self.region = self.__get_region(data)


### PR DESCRIPTION
The `/etc/apt/s3auth.conf` may contain the AWS bucket region and the AWS IAM credentials that will be used to pull from the bucket.

However, if the file does not contain credentials (in particular `AccessKeyId` then the region will be pulled from `$AWS_REGION` and lastly from the ec2 meta-data service.

This change allows the region to be set in `/etc/apt/s3auth.conf` even if the file does not contain any credentials. They will be loaded from the ec2 meta-data service.

This allows an instance (using an instance role) to pull from a bucket in a different region without needing to set $AWS_REGION for apt (which may influence / alter how installed packages function)