### PR TITLE
Exit cleanly when SIGINTed by APT

### DIFF
--- a/s3
+++ b/s3
@@ -22,6 +22,7 @@ import hashlib
 import hmac
 import json
 import os
+import signal
 import socket
 import ssl
 import sys
@@ -678,6 +679,7 @@ class S3_method(object):
 
 
 if __name__ == '__main__':
+    signal.signal(signal.SIGINT, lambda *_: os._exit(128 + signal.SIGINT))  # Exit cleanly if SIGINTed by APT
     try:
         config = '/etc/apt/s3auth.conf'
         if len(sys.argv) == 2 and os.path.isfile(sys.argv[1]):


### PR DESCRIPTION
Cleanly handle spurious `KeyboardInterrupt` traceback when apt cancels the transport method.

Previously, the following output appeared on occasion:
```
$ sudo apt update
Exception ignored in: <module 'threading' from '/usr/lib/python3.12/threading.py'>
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1573, in _shutdown
    def _shutdown():
    
KeyboardInterrupt: 
Hit:1 https://download.docker.com/linux/ubuntu noble InRelease
[...]
```